### PR TITLE
Fix git btn redirection problem

### DIFF
--- a/_includes/external_services.html
+++ b/_includes/external_services.html
@@ -14,9 +14,9 @@
         </a>
       </span>
     </li>
-    <li class="github-watch"><iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=puma&repo=puma&type=watch"
+    <li class="github-watch"><iframe src="http://ghbtns.com/github-btn.html?user=puma&repo=puma&type=watch"
       allowtransparency="true" frameborder="0" scrolling="0" width="62px" height="20px"></iframe></li>
-    <li class="github-fork"><iframe src="http://markdotto.github.com/github-buttons/github-btn.html?user=puma&repo=puma&type=fork"
+    <li class="github-fork"><iframe src="http://ghbtns.com/github-btn.html?user=puma&repo=puma&type=fork"
       allowtransparency="true" frameborder="0" scrolling="0" width="53px" height="20px"></iframe></li>
   </ul>
   <p id="travis-ci-status">


### PR DESCRIPTION
Fixes: https://github.com/puma/puma.io/issues/9

Relates to: https://github.com/markdotto/github-buttons/issues/25
https://github.com/markdotto/github-buttons/commit/f0969165e20d039d182eccb88a51dd3ab52a8f55

Github button project appears to no longer support the old url and is requesting people update to the new url.

Unfortunately, as a result of the changes made sites that reference the old url now appear to be redirecting to github error pages making them mostly useless.
