### PR TITLE
Repair link to Travis CI page for puma/puma

### DIFF
--- a/_includes/external_services.html
+++ b/_includes/external_services.html
@@ -20,6 +20,6 @@
       allowtransparency="true" frameborder="0" scrolling="0" width="53px" height="20px"></iframe></li>
   </ul>
   <p id="travis-ci-status">
-    <a href="http://travis-ci.org/#!/puma/puma">Latest Travis CI Build: <img src="https://secure.travis-ci.org/puma/puma.svg" alt="[View Status]"/></a>
+    <a href="https://travis-ci.org/puma/puma">Latest Travis CI Build: <img src="https://secure.travis-ci.org/puma/puma.svg" alt="[View Status]"/></a>
   </p>
 </div>


### PR DESCRIPTION
This PR fixes the link to the Travis CI build. And uses HTTPS.