### PR TITLE
Fix current version indicator on HTTPS connections

### DIFF
--- a/js/application.js
+++ b/js/application.js
@@ -1,6 +1,6 @@
 $(function() {
 
-  var rg= "http://rubygems.org/api/v1/versions/puma/latest.json?callback=?";
+  var rg= "https://rubygems.org/api/v1/versions/puma/latest.json?callback=?";
   $.getJSON(rg).done(function(data) { $('#version').text(data['version']); });
 
   $('#overview').fitVids();


### PR DESCRIPTION
When viewing the site over HTTPS, the 'Current Release' is displayed
as 'unknown' (the fallback) because mixed-content is blocked:

![before-https](https://user-images.githubusercontent.com/4125410/62046161-23635500-b1ff-11e9-8e8b-b97f322bb098.png)

https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content

Observed in Chrome 75, Firefox 68 and Safari 12.1