### PR TITLE
Allow jQuery to be loaded on HTTPS connections

### DIFF
--- a/_includes/external_services.html
+++ b/_includes/external_services.html
@@ -14,9 +14,9 @@
         </a>
       </span>
     </li>
-    <li class="github-watch"><iframe src="http://ghbtns.com/github-btn.html?user=puma&repo=puma&type=watch"
+    <li class="github-watch"><iframe src="https://ghbtns.com/github-btn.html?user=puma&repo=puma&type=watch"
       allowtransparency="true" frameborder="0" scrolling="0" width="62px" height="20px"></iframe></li>
-    <li class="github-fork"><iframe src="http://ghbtns.com/github-btn.html?user=puma&repo=puma&type=fork"
+    <li class="github-fork"><iframe src="https://ghbtns.com/github-btn.html?user=puma&repo=puma&type=fork"
       allowtransparency="true" frameborder="0" scrolling="0" width="53px" height="20px"></iframe></li>
   </ul>
   <p id="travis-ci-status">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
 
 <link rel="apple-touch-icon-precomposed" href="images/icons/puma-favicon-large.png"/>
 
-<script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/jquery-latest.min.js"></script>
 
 <!--[if IE]><script type="text/javascript" src="js/excanvas.compiled.js"></script><![endif]-->
 


### PR DESCRIPTION
Following on from #24 (which didn't fully fix the issue).

Turns out jQuery also can't be loaded due to mixed-content blocking:
![https-jquery](https://user-images.githubusercontent.com/4125410/62057336-5c0f2880-b217-11e9-8357-2465a938cd5a.png)

Apologies for the trial & error - the content blocking isn't in place when one views the site on `localhost`.