### PR TITLE
Correct link to Bundler website

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ title: A Fast, Concurrent Web Server for Ruby & Rack
     <div id="quickstart-with-bundler" class="quickstart">
       <h3>Quickstart with Bundler</h3>
       <p>
-        If you are using <a href="http://gembundler.com/">Bundler</a>,
+        If you are using <a href="https://bundler.io">Bundler</a>,
         just add Puma to your project's Gemfile:
       </p>
 
@@ -49,7 +49,7 @@ title: A Fast, Concurrent Web Server for Ruby & Rack
     <div id="quickstart-without-bundler" class="quickstart">
       <h3>Quickstart without Bundler</h3>
       <p>
-        If you are not using <a href="http://gembundler.com/">Bundler</a>,
+        If you are not using <a href="https://bundler.io">Bundler</a>,
         you can install Puma directly from the command line:
       </p>
 


### PR DESCRIPTION
It's https://bundler.io now.