### PR TITLE
Remove travis-ci build badges

### DIFF
--- a/_includes/external_services.html
+++ b/_includes/external_services.html
@@ -8,7 +8,9 @@
       <a class="github-button" href="https://github.com/puma/puma/fork" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork puma/puma on GitHub">Fork</a>
     </li>
   </ul>
-  <p id="travis-ci-status">
-    <a href="https://travis-ci.org/puma/puma">Latest Travis CI Build: <img src="https://secure.travis-ci.org/puma/puma.svg" alt="[View Status]"/></a>
+  <p id="ci-status">
+    <a href="https://github.com/puma/puma/actions/workflows/mri.yml"><img src="https://github.com/puma/puma/actions/workflows/mri.yml/badge.svg" alt="[MRI Build Status]"/></a>
+    <a href="https://github.com/puma/puma/actions/workflows/non_mri.yml"><img src="https://github.com/puma/puma/actions/workflows/non_mri.yml/badge.svg" alt="[MRI Build Status]"/></a>
   </p>
 </div>
+

--- a/css/application.css
+++ b/css/application.css
@@ -217,12 +217,12 @@ html {
         top: 1px; }
       #external-services-container #share li.twitter iframe {
         width: 85px !important; }
-  #external-services-container #travis-ci-status {
+  #external-services-container #ci-status {
     margin-top: 5px; }
-    #external-services-container #travis-ci-status a {
+    #external-services-container #ci-status a {
       line-height: 20px;
       text-decoration: none; }
-    #external-services-container #travis-ci-status img {
+    #external-services-container #ci-status img {
       vertical-align: top; }
 
 #page-header.expanded {

--- a/css/application.sass
+++ b/css/application.sass
@@ -324,7 +324,7 @@ html
         top: 1px
       &.twitter iframe
         width: 85px !important
-  #travis-ci-status
+  #ci-status
     margin-top: 5px
     a
       text-decoration: none


### PR DESCRIPTION
The build badge in the upper right corner still links to travis-ci.org which is no longer active and hasn't had a build in 8 months. This swaps it out for the same build badges displayed in the README of the main puma repo and removes references to travis from the CSS rules.