### PR TITLE
Fix dead link in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,3 @@
 <div id="page-footer">
-  Puma &copy; {{ site.time | date: '%Y' }} <a href="http://blog.fallingsnow.net/">Evan Phoenix</a> and Contributors. <br />
+  Puma &copy; {{ site.time | date: '%Y' }} <a href="https://evanphx.dev">Evan Phoenix</a> and Contributors. <br />
 </div>


### PR DESCRIPTION
The link to Evan's blog appears to be dead. This updates it to a functioning link.

It will also have the side effect of updating the copyright notice to 2024 when published (it still says 2023 currently).